### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "extra": {
       "laravel": {
         "providers": [
-          "\\Ladumor\\LaravelPwa\\PwaServiceProvider"
+          "\\Ladumor\\LaravelPwa\\PWAServiceProvider"
         ],
         "aliases": {
           "LaravelPwa": "Ladumor\\LaravelPwa\\LaravelPwa"


### PR DESCRIPTION
PwaServiceProvider should be PWAServiceProvider in order to work well with case sensitive system. Otherwise composer throws an error:

In ProviderRepository.php line 208:                                                            
  Class '\Ladumor\LaravelPwa\PwaServiceProvider' not found  
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1