### PR TITLE
Fix offline detection in PWA

### DIFF
--- a/src/stubs/sw.stub
+++ b/src/stubs/sw.stub
@@ -47,10 +47,12 @@ const returnFromCache = function (request) {
 };
 
 self.addEventListener("fetch", function (event) {
-    event.respondWith(checkResponse(event.request).catch(function () {
-        return returnFromCache(event.request);
-    }));
-    if(!event.request.url.startsWith('http')){
-        event.waitUntil(addToCache(event.request));
+    if (event.request.method === 'GET') {
+        event.respondWith(checkResponse(event.request).catch(function () {
+            return returnFromCache(event.request);
+        }));
+        if (event.request.url.startsWith('http') || event.request.url.startsWith('https')) {
+            event.waitUntil(addToCache(event.request));
+        }
     }
 });


### PR DESCRIPTION
## Fix Offline Detection Issue in PWA

### Description:

This pull request addresses an issue in the PWA app where it incorrectly detects the offline status even when the device is online.

### Changes:

Updated the condition to cache only for 'http' and 'https' requests.